### PR TITLE
Refactor: Power Data Integration for 5 INA228 Sensors

### DIFF
--- a/backend/app/data_collector.py
+++ b/backend/app/data_collector.py
@@ -359,9 +359,35 @@ class DataCollector:
 
     def _generate_power(self, current_time: float, motors: MotorsData) -> PowerData:
         """Generate power system data."""
-        # Battery depletes over time (~0.01%/sec), wraps to 100 at 20%
+        # Try to get real power data from MCU
+        from app.main import real_power_data
+
+        if real_power_data and real_power_data.get('healthy'):
+            # Use REAL data from Power MCU
+            battery_voltage = real_power_data['voltage']
+            current_draw = real_power_data['current']
+
+            # Calculate battery percentage from voltage (simple linear approximation)
+            # TODO: Adjust V_MAX and V_MIN based on actual battery
+            V_MAX = 26.0  # Adjust for your battery
+            V_MIN = 20.0  # Adjust for your battery
+
+            if battery_voltage >= V_MAX:
+                battery_percentage = 100.0
+            elif battery_voltage <= V_MIN:
+                battery_percentage = 0.0
+            else:
+                battery_percentage = ((battery_voltage - V_MIN) / (V_MAX - V_MIN)) * 100.0
+
+            return PowerData(
+                battery_percentage=battery_percentage,
+                battery_voltage=battery_voltage,
+                current_draw=current_draw,
+            )
+
+        # Fallback to MOCK data if no real data available
         elapsed = current_time - self._start_time
-        depletion = elapsed * 0.01  
+        depletion = elapsed * 0.01
         self._battery_percentage = 100.0 - depletion
 
         if self._battery_percentage <= 20.0:

--- a/backend/app/data_collector.py
+++ b/backend/app/data_collector.py
@@ -396,6 +396,13 @@ class DataCollector:
                     current_draw=total_current,
                     sensors=list(power_update.sensors),
                     is_stale=False,
+                    relay1=power_update.relay1,
+                    relay2=power_update.relay2,
+                    relay3=power_update.relay3,
+                    relay4=power_update.relay4,
+                    relay5=power_update.relay5,
+                    relay6=power_update.relay6,
+                    relay7=power_update.relay7,
                 )
 
         # Check if we have stale data
@@ -428,6 +435,13 @@ class DataCollector:
             current_draw=current_draw,
             sensors=[],
             is_stale=is_stale,
+            relay1=False,
+            relay2=False,
+            relay3=False,
+            relay4=False,
+            relay5=False,
+            relay6=False,
+            relay7=False,
         )
 
     def _generate_system(self, current_time: float, motors: MotorsData) -> SystemData:

--- a/backend/app/data_collector.py
+++ b/backend/app/data_collector.py
@@ -1,4 +1,5 @@
 import math
+import os
 import random
 import time
 from datetime import datetime
@@ -12,11 +13,17 @@ from app.models import (
     MotorsData,
     MotorStatus,
     PowerData,
+    SensorReading,
     SensorsData,
     SystemData,
     SystemHealthStatus,
     TelemetryData,
 )
+from app.power_state import power_state
+
+# Battery voltage thresholds for percentage calculation (configurable via env vars)
+BATTERY_V_MAX = float(os.getenv("BATTERY_V_MAX", "26.0"))
+BATTERY_V_MIN = float(os.getenv("BATTERY_V_MIN", "20.0"))
 
 
 class DataCollector:
@@ -359,33 +366,42 @@ class DataCollector:
 
     def _generate_power(self, current_time: float, motors: MotorsData) -> PowerData:
         """Generate power system data."""
-        # Try to get real power data from MCU
-        from app.main import real_power_data
+        power_update = power_state.get_sync()
 
-        if real_power_data and real_power_data.get('healthy'):
-            # Use REAL data from Power MCU
-            battery_voltage = real_power_data['voltage']
-            current_draw = real_power_data['current']
+        if power_update is not None:
+            # Use real MCU data - first healthy sensor for voltage, sum currents
+            battery_voltage = 0.0
+            total_current = 0.0
+            healthy_count = 0
+            
+            for sensor in power_update.sensors:
+                if sensor.healthy:
+                    if healthy_count == 0:
+                        battery_voltage = sensor.voltage
+                    total_current += sensor.current
+                    healthy_count += 1
+            
+            if healthy_count > 0:
+                # Calculate battery percentage from voltage
+                if battery_voltage >= BATTERY_V_MAX:
+                    battery_percentage = 100.0
+                elif battery_voltage <= BATTERY_V_MIN:
+                    battery_percentage = 0.0
+                else:
+                    battery_percentage = ((battery_voltage - BATTERY_V_MIN) / (BATTERY_V_MAX - BATTERY_V_MIN)) * 100.0
 
-            # Calculate battery percentage from voltage (simple linear approximation)
-            # TODO: Adjust V_MAX and V_MIN based on actual battery
-            V_MAX = 26.0  # Adjust for your battery
-            V_MIN = 20.0  # Adjust for your battery
+                return PowerData(
+                    battery_percentage=battery_percentage,
+                    battery_voltage=battery_voltage,
+                    current_draw=total_current,
+                    sensors=list(power_update.sensors),
+                    is_stale=False,
+                )
 
-            if battery_voltage >= V_MAX:
-                battery_percentage = 100.0
-            elif battery_voltage <= V_MIN:
-                battery_percentage = 0.0
-            else:
-                battery_percentage = ((battery_voltage - V_MIN) / (V_MAX - V_MIN)) * 100.0
+        # Check if we have stale data
+        is_stale = power_state.is_stale() and power_state.last_update_time > 0
 
-            return PowerData(
-                battery_percentage=battery_percentage,
-                battery_voltage=battery_voltage,
-                current_draw=current_draw,
-            )
-
-        # Fallback to MOCK data if no real data available
+        # Fallback to mock data
         elapsed = current_time - self._start_time
         depletion = elapsed * 0.01
         self._battery_percentage = 100.0 - depletion
@@ -410,6 +426,8 @@ class DataCollector:
             battery_percentage=self._battery_percentage,
             battery_voltage=battery_voltage,
             current_draw=current_draw,
+            sensors=[],
+            is_stale=is_stale,
         )
 
     def _generate_system(self, current_time: float, motors: MotorsData) -> SystemData:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 
 from app.websocket import websocket_endpoint
 
@@ -18,6 +19,20 @@ app = FastAPI(
     description="WebSocket server for streaming exoskeleton telemetry data",
     version="0.1.0",
 )
+
+# Global variable to store real power data from MCU
+real_power_data = None
+
+# Pydantic model for power data
+class PowerUpdate(BaseModel):
+    voltage: float
+    current: float
+    power: float
+    healthy: int
+    voltage2: float
+    current2: float
+    power2: float
+    healthy2: int
 
 # Configure CORS for frontend development
 # Using allow_origins=["*"] ensures WebSocket upgrades are not blocked by
@@ -39,6 +54,14 @@ app.add_middleware(
 async def health_check():
     """Health check endpoint to verify the server is running."""
     return {"status": "healthy", "service": "exoskeleton-telemetry"}
+
+
+@app.post("/power/update")
+async def update_power(data: PowerUpdate):
+    """Receive real-time power data from MCU via serial bridge"""
+    global real_power_data
+    real_power_data = data.dict()
+    return {"status": "ok"}
 
 
 @app.websocket("/ws")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,8 +2,9 @@ import logging
 
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
 
+from app.models import PowerUpdate
+from app.power_state import power_state
 from app.websocket import websocket_endpoint
 
 # ---------------------------------------------------------------------------
@@ -19,20 +20,6 @@ app = FastAPI(
     description="WebSocket server for streaming exoskeleton telemetry data",
     version="0.1.0",
 )
-
-# Global variable to store real power data from MCU
-real_power_data = None
-
-# Pydantic model for power data
-class PowerUpdate(BaseModel):
-    voltage: float
-    current: float
-    power: float
-    healthy: int
-    voltage2: float
-    current2: float
-    power2: float
-    healthy2: int
 
 # Configure CORS for frontend development
 # Using allow_origins=["*"] ensures WebSocket upgrades are not blocked by
@@ -58,9 +45,8 @@ async def health_check():
 
 @app.post("/power/update")
 async def update_power(data: PowerUpdate):
-    """Receive real-time power data from MCU via serial bridge"""
-    global real_power_data
-    real_power_data = data.dict()
+    """Receive real-time power data from MCU via serial bridge."""
+    await power_state.update(data)
     return {"status": "ok"}
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -97,6 +97,13 @@ class PowerData(BaseModel):
         default_factory=list, description="Raw readings from INA228 sensors (empty if using mock data)"
     )
     is_stale: bool = Field(default=False, description="True if sensor data is stale")
+    relay1: bool = Field(default=False, description="Relay 1 state")
+    relay2: bool = Field(default=False, description="Relay 2 state")
+    relay3: bool = Field(default=False, description="Relay 3 state")
+    relay4: bool = Field(default=False, description="Relay 4 state")
+    relay5: bool = Field(default=False, description="Relay 5 state")
+    relay6: bool = Field(default=False, description="Relay 6 state")
+    relay7: bool = Field(default=False, description="Relay 7 state")
 
 
 class PowerUpdate(BaseModel):
@@ -108,6 +115,13 @@ class PowerUpdate(BaseModel):
         max_length=5,
         description="Readings from 5 INA228 power sensors"
     )
+    relay1: bool = Field(default=False, description="Relay 1 state")
+    relay2: bool = Field(default=False, description="Relay 2 state")
+    relay3: bool = Field(default=False, description="Relay 3 state")
+    relay4: bool = Field(default=False, description="Relay 4 state")
+    relay5: bool = Field(default=False, description="Relay 5 state")
+    relay6: bool = Field(default=False, description="Relay 6 state")
+    relay7: bool = Field(default=False, description="Relay 7 state")
 
 
 class SystemData(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -76,6 +76,15 @@ class SensorsData(BaseModel):
     right_knee: IMUData
 
 
+class SensorReading(BaseModel):
+    """Reading from a single INA228 power sensor."""
+
+    voltage: float = Field(..., ge=0, description="Voltage in Volts")
+    current: float = Field(..., description="Current in Amperes")
+    power: float = Field(..., ge=0, description="Power in Watts")
+    healthy: bool = Field(..., description="Sensor health flag")
+
+
 class PowerData(BaseModel):
     """Power system telemetry data."""
 
@@ -84,6 +93,21 @@ class PowerData(BaseModel):
     )
     battery_voltage: float = Field(..., description="Battery voltage in Volts")
     current_draw: float = Field(..., description="Total current draw in Amperes")
+    sensors: List[SensorReading] = Field(
+        default_factory=list, description="Raw readings from INA228 sensors (empty if using mock data)"
+    )
+    is_stale: bool = Field(default=False, description="True if sensor data is stale")
+
+
+class PowerUpdate(BaseModel):
+    """Power data received from MCU via serial bridge (5 INA228 sensors)."""
+
+    sensors: List[SensorReading] = Field(
+        ...,
+        min_length=5,
+        max_length=5,
+        description="Readings from 5 INA228 power sensors"
+    )
 
 
 class SystemData(BaseModel):

--- a/backend/app/power_state.py
+++ b/backend/app/power_state.py
@@ -1,0 +1,65 @@
+"""Async-safe shared state for power data from MCU."""
+
+import asyncio
+import logging
+import os
+import time
+from typing import Optional
+
+from app.models import PowerUpdate
+
+logger = logging.getLogger(__name__)
+
+# Configuration (env vars)
+STALE_THRESHOLD_SECONDS = float(os.getenv("POWER_STALE_THRESHOLD", "5.0"))
+VOLTAGE_MIN = float(os.getenv("VOLTAGE_VALID_MIN", "0.0"))
+VOLTAGE_MAX = float(os.getenv("VOLTAGE_VALID_MAX", "60.0"))
+
+
+class PowerState:
+    """Async-safe container for power sensor data with staleness detection."""
+
+    def __init__(self, stale_threshold_seconds: float = 5.0):
+        self._data: Optional[PowerUpdate] = None
+        self._last_update: float = 0.0
+        self._lock = asyncio.Lock()
+        self._stale_threshold = stale_threshold_seconds
+
+    async def update(self, data: PowerUpdate) -> None:
+        """Store new power data with validation."""
+        for i, sensor in enumerate(data.sensors):
+            if not sensor.healthy:
+                logger.warning(f"Sensor {i+1} reports unhealthy")
+            if not (VOLTAGE_MIN <= sensor.voltage <= VOLTAGE_MAX):
+                logger.warning(f"Sensor {i+1} voltage {sensor.voltage}V out of range")
+        
+        async with self._lock:
+            self._data = data
+            self._last_update = time.time()
+
+    async def get(self) -> Optional[PowerUpdate]:
+        """Get current data if not stale (async)."""
+        async with self._lock:
+            if self._data is None or self.is_stale():
+                return None
+            return self._data
+
+    def get_sync(self) -> Optional[PowerUpdate]:
+        """Get current data if not stale (sync, for thread pools)."""
+        if self._data is None or self.is_stale():
+            return None
+        return self._data
+
+    def is_stale(self) -> bool:
+        """Check if data is stale."""
+        if self._data is None:
+            return True
+        return (time.time() - self._last_update) > self._stale_threshold
+
+    @property
+    def last_update_time(self) -> float:
+        return self._last_update
+
+
+# Singleton instance
+power_state = PowerState(stale_threshold_seconds=STALE_THRESHOLD_SECONDS)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -169,40 +169,83 @@ function App() {
           </div>
 
           {/* Power Section */}
-          <div className="bg-gray-800 p-6 rounded-lg border border-gray-700">
+          <div className="bg-gray-800 p-6 rounded-lg border border-gray-700 lg:col-span-2">
             <h2 className="text-xl font-bold mb-4 text-blue-400">Power System</h2>
 
-            <div className="space-y-3">
-              <div className="flex justify-between">
-                <span className="text-gray-400">Battery:</span>
-                <span className={`font-semibold ${getBatteryColor(telemetry.power.battery_percentage)}`}>
-                  {telemetry.power.battery_percentage.toFixed(1)}%
-                </span>
+            {/* Stale Data Warning */}
+            {telemetry.power.is_stale && (
+              <div className="mb-4 p-3 bg-yellow-900/30 border border-yellow-500 rounded text-yellow-300 flex items-center gap-2">
+                <span className="text-lg">⚠</span>
+                <span>Sensor data is stale - using mock values</span>
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* Battery Summary */}
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Battery:</span>
+                  <span className={`font-semibold ${getBatteryColor(telemetry.power.battery_percentage)}`}>
+                    {telemetry.power.battery_percentage.toFixed(1)}%
+                  </span>
+                </div>
+
+                {/* Battery Visual Indicator */}
+                <div className="w-full bg-gray-700 rounded-full h-4 overflow-hidden">
+                  <div
+                    className={`h-full transition-all duration-300 ${
+                      telemetry.power.battery_percentage > 50
+                        ? 'bg-green-500'
+                        : telemetry.power.battery_percentage > 20
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                    }`}
+                    style={{ width: `${telemetry.power.battery_percentage}%` }}
+                  />
+                </div>
+
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Voltage:</span>
+                  <span className="font-mono">{telemetry.power.battery_voltage.toFixed(2)} V</span>
+                </div>
+
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Total Current:</span>
+                  <span className="font-mono">{telemetry.power.current_draw.toFixed(2)} A</span>
+                </div>
               </div>
 
-              {/* Battery Visual Indicator */}
-              <div className="w-full bg-gray-700 rounded-full h-4 overflow-hidden">
-                <div
-                  className={`h-full transition-all duration-300 ${
-                    telemetry.power.battery_percentage > 50
-                      ? 'bg-green-500'
-                      : telemetry.power.battery_percentage > 20
-                      ? 'bg-yellow-500'
-                      : 'bg-red-500'
-                  }`}
-                  style={{ width: `${telemetry.power.battery_percentage}%` }}
-                />
-              </div>
+              {/* Individual Sensors */}
+              {telemetry.power.sensors.length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-sm text-gray-400 mb-2">INA228 Sensors:</div>
+                  <div className="grid grid-cols-1 gap-2">
+                    {telemetry.power.sensors.map((sensor, idx) => (
+                      <div
+                        key={idx}
+                        className={`flex justify-between items-center p-2 rounded text-sm ${
+                          sensor.healthy ? 'bg-gray-700/50' : 'bg-red-900/30 border border-red-500'
+                        }`}
+                      >
+                        <span className="text-gray-400">S{idx + 1}:</span>
+                        <span className="font-mono">
+                          {sensor.voltage.toFixed(1)}V / {sensor.current.toFixed(2)}A
+                        </span>
+                        <span className={sensor.healthy ? 'text-green-400' : 'text-red-400'}>
+                          {sensor.healthy ? '✓' : '✗'}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
-              <div className="flex justify-between">
-                <span className="text-gray-400">Voltage:</span>
-                <span className="font-mono">{telemetry.power.battery_voltage.toFixed(2)} V</span>
-              </div>
-
-              <div className="flex justify-between">
-                <span className="text-gray-400">Current Draw:</span>
-                <span className="font-mono">{telemetry.power.current_draw.toFixed(2)} A</span>
-              </div>
+              {/* No sensors message */}
+              {telemetry.power.sensors.length === 0 && (
+                <div className="flex items-center justify-center text-gray-500 text-sm">
+                  No sensor data (using mock values)
+                </div>
+              )}
             </div>
           </div>
 

--- a/frontend/src/types/telemetry.ts
+++ b/frontend/src/types/telemetry.ts
@@ -64,6 +64,13 @@ export interface PowerData {
     current_draw: number;
     sensors: SensorReading[];
     is_stale: boolean;
+    relay1: boolean;
+    relay2: boolean;
+    relay3: boolean;
+    relay4: boolean;
+    relay5: boolean;
+    relay6: boolean;
+    relay7: boolean;
 }
 
 export interface SystemData {

--- a/frontend/src/types/telemetry.ts
+++ b/frontend/src/types/telemetry.ts
@@ -51,10 +51,19 @@ export interface SensorsData {
     right_knee: IMUData;
 }
 
+export interface SensorReading {
+    voltage: number;
+    current: number;
+    power: number;
+    healthy: boolean;
+}
+
 export interface PowerData {
     battery_percentage: number;
     battery_voltage: number;
     current_draw: number;
+    sensors: SensorReading[];
+    is_stale: boolean;
 }
 
 export interface SystemData {

--- a/scripts/power_serial_bridge.py
+++ b/scripts/power_serial_bridge.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Serial-to-Backend Bridge for Power MCU Data
+Reads power telemetry from STM32 via UART and updates the backend.
+"""
+
+import serial
+import json
+import time
+import sys
+import requests
+
+class PowerSerialBridge:
+    def __init__(self, serial_port: str, backend_url: str = "http://localhost:8000", baudrate: int = 115200):
+        self.serial_port = serial_port
+        self.baudrate = baudrate
+        self.backend_url = backend_url
+        self.ser = None
+
+    def connect_serial(self):
+        """Connect to serial port"""
+        try:
+            self.ser = serial.Serial(
+                port=self.serial_port,
+                baudrate=self.baudrate,
+                timeout=1.0
+            )
+            print(f"✓ Connected to {self.serial_port} at {self.baudrate} baud")
+            time.sleep(2)  # Wait for MCU to stabilize
+            return True
+        except serial.SerialException as e:
+            print(f"✗ Failed to connect to {self.serial_port}: {e}")
+            return False
+
+    def read_and_parse(self):
+        """Read one line from serial and parse JSON"""
+        if not self.ser or not self.ser.is_open:
+            return None
+
+        try:
+            line = self.ser.readline().decode('utf-8').strip()
+            if line:
+                data = json.loads(line)
+                return data
+        except json.JSONDecodeError:
+            # Silently ignore JSON errors (common on startup)
+            return None
+        except UnicodeDecodeError:
+            # Silently ignore unicode errors (common on startup)
+            return None
+        except Exception as e:
+            print(f"✗ Read error: {e}")
+            return None
+
+    def update_backend(self, power_data):
+        """Send power data to backend via HTTP POST"""
+        try:
+            response = requests.post(
+                f"{self.backend_url}/power/update",
+                json=power_data,
+                timeout=0.5
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            # Backend not available - continue silently
+            return False
+
+    def run(self):
+        """Main loop - read serial and update backend"""
+        if not self.connect_serial():
+            return
+
+        print(f"Reading power data and forwarding to {self.backend_url}")
+        print("Press Ctrl+C to stop\n")
+
+        update_count = 0
+        error_count = 0
+
+        try:
+            while True:
+                power_data = self.read_and_parse()
+                if power_data:
+                    update_count += 1
+
+                    # Display formatted output
+                    print(f"[{update_count}] Sensor1: {power_data['voltage']:.2f}V {power_data['current']:.3f}A {power_data['power']:.2f}W [H:{power_data['healthy']}] | "
+                          f"Sensor2: {power_data['voltage2']:.2f}V {power_data['current2']:.3f}A {power_data['power2']:.2f}W [H:{power_data['healthy2']}]", end='')
+
+                    # Update backend
+                    if self.update_backend(power_data):
+                        print(" → Backend ✓")
+                    else:
+                        error_count += 1
+                        if error_count % 10 == 1:  # Only print occasionally to avoid spam
+                            print(" → Backend ✗ (not running?)")
+                        else:
+                            print()
+
+                time.sleep(0.01)
+
+        except KeyboardInterrupt:
+            print(f"\n\n✓ Stopped by user")
+            print(f"Total updates: {update_count}")
+        finally:
+            if self.ser:
+                self.ser.close()
+                print("✓ Serial port closed")
+
+def main():
+    # Parse command line arguments
+    port = sys.argv[1] if len(sys.argv) > 1 else '/dev/ttyUSB0'
+    backend = sys.argv[2] if len(sys.argv) > 2 else 'http://localhost:8000'
+
+    print(f"Power MCU Serial Bridge")
+    print(f"Port: {port}")
+    print(f"Backend: {backend}")
+    print(f"Baud: 115200\n")
+
+    bridge = PowerSerialBridge(serial_port=port, backend_url=backend, baudrate=115200)
+    bridge.run()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/power_serial_bridge.py
+++ b/scripts/power_serial_bridge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Serial-to-Backend Bridge for Power MCU Data
-Reads power telemetry from STM32 via UART and updates the backend.
+Reads power telemetry from STM32 via UART (5 INA228 sensors) and updates the backend.
 """
 
 import serial
@@ -9,6 +9,34 @@ import json
 import time
 import sys
 import requests
+
+# Number of INA228 sensors
+NUM_SENSORS = 5
+
+
+def transform_mcu_data(raw_data: dict) -> dict:
+    """Transform raw MCU data to API format."""
+    # If already in new format, just ensure healthy is bool
+    if "sensors" in raw_data:
+        for sensor in raw_data["sensors"]:
+            if isinstance(sensor.get("healthy"), int):
+                sensor["healthy"] = bool(sensor["healthy"])
+        return raw_data
+    
+    # Transform legacy flat format to new format
+    sensors = []
+    for i in range(1, NUM_SENSORS + 1):
+        suffix = "" if i == 1 else str(i)
+        sensor = {
+            "voltage": raw_data.get(f"voltage{suffix}", raw_data.get(f"voltage{i}", 0.0)),
+            "current": raw_data.get(f"current{suffix}", raw_data.get(f"current{i}", 0.0)),
+            "power": raw_data.get(f"power{suffix}", raw_data.get(f"power{i}", 0.0)),
+            "healthy": bool(raw_data.get(f"healthy{suffix}", raw_data.get(f"healthy{i}", 0))),
+        }
+        sensors.append(sensor)
+    
+    return {"sensors": sensors}
+
 
 class PowerSerialBridge:
     def __init__(self, serial_port: str, backend_url: str = "http://localhost:8000", baudrate: int = 115200):
@@ -65,12 +93,20 @@ class PowerSerialBridge:
             # Backend not available - continue silently
             return False
 
+    def format_sensor_display(self, sensors: list) -> str:
+        """Format sensor data for console display."""
+        parts = []
+        for i, s in enumerate(sensors, 1):
+            healthy = "✓" if s["healthy"] else "✗"
+            parts.append(f"S{i}: {s['voltage']:.1f}V {s['current']:.2f}A [{healthy}]")
+        return " | ".join(parts)
+
     def run(self):
         """Main loop - read serial and update backend"""
         if not self.connect_serial():
             return
 
-        print(f"Reading power data and forwarding to {self.backend_url}")
+        print(f"Reading power data from {NUM_SENSORS} sensors and forwarding to {self.backend_url}")
         print("Press Ctrl+C to stop\n")
 
         update_count = 0
@@ -78,13 +114,16 @@ class PowerSerialBridge:
 
         try:
             while True:
-                power_data = self.read_and_parse()
-                if power_data:
+                raw_data = self.read_and_parse()
+                if raw_data:
                     update_count += 1
+                    
+                    # Transform to API format
+                    power_data = transform_mcu_data(raw_data)
 
                     # Display formatted output
-                    print(f"[{update_count}] Sensor1: {power_data['voltage']:.2f}V {power_data['current']:.3f}A {power_data['power']:.2f}W [H:{power_data['healthy']}] | "
-                          f"Sensor2: {power_data['voltage2']:.2f}V {power_data['current2']:.3f}A {power_data['power2']:.2f}W [H:{power_data['healthy2']}]", end='')
+                    display = self.format_sensor_display(power_data["sensors"])
+                    print(f"[{update_count}] {display}", end='')
 
                     # Update backend
                     if self.update_backend(power_data):
@@ -106,12 +145,13 @@ class PowerSerialBridge:
                 self.ser.close()
                 print("✓ Serial port closed")
 
+
 def main():
     # Parse command line arguments
     port = sys.argv[1] if len(sys.argv) > 1 else '/dev/ttyUSB0'
     backend = sys.argv[2] if len(sys.argv) > 2 else 'http://localhost:8000'
 
-    print(f"Power MCU Serial Bridge")
+    print(f"Power MCU Serial Bridge (5 INA228 sensors)")
     print(f"Port: {port}")
     print(f"Backend: {backend}")
     print(f"Baud: 115200\n")


### PR DESCRIPTION
## Summary
Refactors power data integration to support 5 INA228 sensors with proper async-safe state management.

## Changes

### Backend
- Replace `real_power_data` global with async-safe `PowerState` class
- Move `PowerUpdate` model to `models.py`
- Expand schema: `List[SensorReading]` with exactly 5 sensors
- Add staleness detection (`POWER_STALE_THRESHOLD` env var, default 5s)
- Make battery thresholds configurable (`BATTERY_V_MAX`, `BATTERY_V_MIN`)
- Add voltage range validation with logging
- Remove circular import in `data_collector.py`
- **Add relay1-relay7 boolean fields for relay status**

### Frontend
- Display all 5 sensors with voltage, current, and health status
- Add stale-data warning indicator
- Update `PowerData` types with relay fields

### Scripts
- Update `power_serial_bridge.py` for 5 sensors
- Backward-compatible transform for legacy MCU format

## New Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| `BATTERY_V_MAX` | 26.0 | Max battery voltage (100%) |
| `BATTERY_V_MIN` | 20.0 | Min battery voltage (0%) |
| `POWER_STALE_THRESHOLD` | 5.0 | Seconds before data is stale |
| `VOLTAGE_VALID_MIN` | 0.0 | Min valid voltage for validation |
| `VOLTAGE_VALID_MAX` | 60.0 | Max valid voltage for validation |

## Completed
- [x] Relay status (7 relays as flat booleans per @umarkhan135)

Closes #15